### PR TITLE
Add DeepL glossary support via optional GlossaryId config

### DIFF
--- a/lib/service/translation/deepl.dart
+++ b/lib/service/translation/deepl.dart
@@ -13,11 +13,13 @@ class DeepLTranslationService extends AbstractTranslationService
   final HttpClient _httpClient;
   final String apiKey;
   final Logger logger;
+  final String? glossaryId;
 
   DeepLTranslationService({
     required String url,
     required this.apiKey,
     required this.logger,
+    this.glossaryId,
   }) : _httpClient = HttpClient(
           baseUrl: url,
           logger: logger,
@@ -44,6 +46,7 @@ class DeepLTranslationService extends AbstractTranslationService
         'source_lang': sourceLanguage,
         'target_lang': target,
         'text': Uri.encodeComponent(source),
+        if (glossaryId != null) 'glossary_id': glossaryId!,
       },
       decoder: (response) => _decodeTranslationJson(response.body),
       body: {},
@@ -73,6 +76,9 @@ class DeepLTranslationService extends AbstractTranslationService
     List<MapEntry<String, String>> parameters = [];
     parameters.add(MapEntry('source_lang', sourceLanguage));
     parameters.add(MapEntry('target_lang', target));
+    if (glossaryId != null) {
+      parameters.add(MapEntry('glossary_id', glossaryId!));
+    }
     for (final source in sources) {
       parameters.add(MapEntry('text', Uri.encodeComponent(source)));
     }

--- a/lib/service/translation/service_factory.dart
+++ b/lib/service/translation/service_factory.dart
@@ -177,10 +177,13 @@ class TranslationServiceFactory {
     final serviceKey = 'DeepL';
     final urlKey = 'Url';
     final apiKeyKey = 'ApiKey';
+    final glossaryIdKey = 'GlossaryId';
 
     final url = configuration.lookupNested('$serviceKey:$urlKey');
 
     final apiKey = configuration.lookupNested('$serviceKey:$apiKeyKey');
+
+    final glossaryId = configuration.lookupNested('$serviceKey:$glossaryIdKey');
 
     if (url == null) {
       throw Exception('$serviceKey:$urlKey is not defined');
@@ -194,6 +197,7 @@ class TranslationServiceFactory {
       url: url,
       apiKey: apiKey,
       logger: logger,
+      glossaryId: glossaryId,
     );
   }
 


### PR DESCRIPTION
Adds support for DeepL's glossary feature, which prevents specific terms (e.g., brand names) from being translated. The glossary ID is read from the config file under the `DeepL.GlossaryId` key and passed to both single and bulk translate API requests.

This is fully backwards-compatible — GlossaryId is optional and the behavior is unchanged when not configured.

Configuration example:
```json
{
  "DeepL": {
    "Url": "https://api.deepl.com",
    "ApiKey": "your-api-key",
    "GlossaryId": "your-glossary-id"
  }
}
```